### PR TITLE
Set runInShell to true to make it run under Windows

### DIFF
--- a/lib/peanut.dart
+++ b/lib/peanut.dart
@@ -37,7 +37,7 @@ Future<Null> run(
   try {
     var args = ['build', '--output', tempDir.path, targetDir];
 
-    Process process = await Process.start('pub', args);
+    Process process = await Process.start('pub', args, runInShell: true);
 
     process.stdout.transform(_lineDecoder).listen((line) {
       stdout.writeln(line);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: peanut
-version: 0.0.1+1
+version: 0.0.1+2
 description: pub build to gh-pages
 author: Kevin Moore <github@j832.com>
 homepage: https://github.com/kevmoo/peanut.dart


### PR DESCRIPTION
Not sure if this is a bug in `Process` or if it's just something that has to be done to make it work with Windows.

If I don't add `runInShell: true`, then it'll just exit with: ProcessException: The system cannot find the file specified.