### PR TITLE
Suggest git command when done

### DIFF
--- a/lib/peanut.dart
+++ b/lib/peanut.dart
@@ -60,7 +60,9 @@ Future<Null> run(String targetDir, String targetBranch, String commitMessage,
       print('There was no change in branch. No commit created.');
     } else {
       print('Branch "$targetBranch" was updated '
-          'with "pub build" output from "$targetDir".');
+          'with "pub build" output from "$targetDir".\n'
+          'You might want to run the following command now:\n'
+          '\$ git update-ref refs/heads/gh-pages origin/gh-pages');
     }
   } catch (e, stack) {
     print(e);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: peanut
-version: 0.0.2
+version: 0.0.3
 description: pub build to gh-pages
 author: Kevin Moore <github@j832.com>
 homepage: https://github.com/kevmoo/peanut.dart


### PR DESCRIPTION
I don't run peanut very often so I don't have the follow-up git command in memory. I hate having to context-switch to Google / github.

Also, bumping the version number (and running `pub publish`) means the docs on pub.dartlang.org will be in sync with what's in github.

No functional change.
