### PR TITLE
Suggest git command when done

### DIFF
--- a/lib/peanut.dart
+++ b/lib/peanut.dart
@@ -68,7 +68,9 @@ Future<Null> run(String targetDir, String targetBranch, String commitMessage,
       print('There was no change in branch. No commit created.');
     } else {
       print('Branch "$targetBranch" was updated '
-          'with `$command` output from `$targetDir`.');
+          'with `$command` output from `$targetDir`.\n'
+          'You might want to run the following command now:\n'
+          '\$ git update-ref refs/heads/gh-pages origin/gh-pages');
     }
   } finally {
     await tempDir.delete(recursive: true);


### PR DESCRIPTION
I don't run peanut very often so I don't have the follow-up git command in memory. I hate having to context-switch to Google / github.

Also, bumping the version number (and running `pub publish`) means the docs on pub.dartlang.org will be in sync with what's in github.

No functional change.
