### PR TITLE
Add Flutter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.0
+
+- Flutter apps are now built if peanut is enabled using `flutter pub global
+  activate`. Running `flutter pub global run peanut:peanut` will use the flutter
+  CLI instead of `build_runner`
+
 ## 3.3.0
 
 - Parse command line arguments when a `peaunut.yaml` configuration file exists

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ $ peanut
 This will build your project into a temporary directory, and then it will update
 the local `gh-pages` branch with its contents.
 
+## Flutter
+
+Flutter apps can be built by running peanut with the Flutter SDK.
+
+Installing: 
+
+```
+$ flutter pub global activate peanut
+```
+
+Running:
+
+```
+$ flutter pub global run peanut:peanut
+```
+
 ## Options
 
 ```console

--- a/lib/src/flutter.dart
+++ b/lib/src/flutter.dart
@@ -30,6 +30,9 @@ Future<void> runFlutterBuild(
 $_commandPrefix$prettyArgs
 '''));
 
+  // Run flutter clean to remove cached build output
+  await runProcess(flutterPath, ['clean'], workingDirectory: pkgDirectory);
+
   // Build the app
   await runProcess(flutterPath, args, workingDirectory: pkgDirectory);
 

--- a/lib/src/flutter.dart
+++ b/lib/src/flutter.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:io/ansi.dart' as ansi;
+import 'package:path/path.dart' as p;
+
+import 'options.dart';
+import 'utils.dart';
+
+Future<void> runFlutterBuild(
+  String pkgDirectory,
+  String outputDir,
+  Options options,
+) async {
+  final args = <String>[
+    'build',
+    'web',
+  ];
+
+  final prettyArgList = args.toList()..insert(0, 'flutter');
+  final prettyArgs = prettyArgList.join(' ');
+
+  print(ansi.styleBold.wrap('''
+$_commandPrefix$prettyArgs
+'''));
+  await runProcess(flutterPath, args, workingDirectory: pkgDirectory);
+  final sourceDir = p.absolute('build/web');
+  await copyFilesRecursive(sourceDir, outputDir);
+}
+
+Future copyFilesRecursive(String srcDir, String destDir) async {
+  final parent = Directory(srcDir);
+  await for (var entity in parent.list(recursive: true)) {
+    final relativePath = p.relative(entity.path, from: parent.path);
+    final newPath = p.join(destDir, relativePath);
+    if (entity is File) {
+      await entity.copy(newPath);
+    } else if (entity is Directory) {
+      final newPathUri = Uri.parse(newPath);
+      final dir = Directory.fromUri(newPathUri);
+      await dir.create(recursive: true);
+      assert(await dir.exists());
+    }
+  }
+}
+
+const _commandPrefix = 'Command:     ';

--- a/lib/src/flutter.dart
+++ b/lib/src/flutter.dart
@@ -13,7 +13,7 @@ Future<void> runFlutterBuild(
   Options options,
 ) async {
   if (targets.entries.length != 1) {
-    // TODO(johnpryan): investigate how the flutter command builds test output
+    // TODO(johnpryan): investigate how the flutter command handles targets
     print('Warning: only 1 target (web) is supported for Flutter apps');
     return;
   }

--- a/lib/src/flutter.dart
+++ b/lib/src/flutter.dart
@@ -5,6 +5,7 @@ import 'package:io/ansi.dart' as ansi;
 import 'package:path/path.dart' as p;
 
 import 'options.dart';
+import 'peanut_exception.dart';
 import 'utils.dart';
 
 Future<void> runFlutterBuild(
@@ -13,9 +14,7 @@ Future<void> runFlutterBuild(
   Options options,
 ) async {
   if (targets.entries.length != 1) {
-    // TODO(johnpryan): investigate how the flutter command handles targets
-    print('Warning: only 1 target (web) is supported for Flutter apps');
-    return;
+    throw PeanutException('only 1 target (web) is supported for Flutter apps');
   }
 
   final args = <String>[

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -2,6 +2,13 @@ import 'package:path/path.dart' as p;
 
 import 'peanut_exception.dart';
 
+/// Creates a Map where the keys are the relative package directory and the
+/// values are the subdirectories to build. For example, in a typical project
+/// this will be {'.': {'web'}} indicating that the root directory of the
+/// package will target the web/ directory for it's entrypoint.
+///
+/// See https://github.com/dart-lang/build/blob/master/build_config/README.md
+/// for more information on build targets
 Map<String, Set<String>> targetDirectories(
   String workingDir,
   Iterable<String> directories,
@@ -34,6 +41,10 @@ Map<String, Set<String>> targetDirectories(
   return targetDirs;
 }
 
+/// Creates a Map where the keys are the relative paths in the output directory
+/// and the values are relative paths to the target directories they were built
+/// from. For example, a project with two targets, 'example', and 'web' results
+/// in {'example': 'example', 'web': 'web'}
 Map<String, String> outputDirectoryMap(Map<String, Set<String>> input) {
   // Only one package, so use the build directory paths
   if (input.length == 1) {

--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -7,6 +7,7 @@ import 'package:io/ansi.dart' as ansi;
 import 'package:path/path.dart' as p;
 
 import 'build_runner.dart';
+import 'flutter.dart';
 import 'helpers.dart';
 import 'options.dart';
 import 'peanut_exception.dart';
@@ -118,11 +119,19 @@ Future<void> run({Options options, String workingDir}) async {
 Package:     $pkgPath$countDetails
 Directories: ${sourcePkg.value.join(', ')}'''));
 
-      await runBuildRunner(
-        pkgNormalize(workingDir, sourcePkg.key),
-        targets,
-        options,
-      );
+      if (isFlutterSdk()) {
+        await runFlutterBuild(
+          pkgNormalize(workingDir, sourcePkg.key),
+          tempDir.path,
+          options,
+        );
+      } else {
+        await runBuildRunner(
+          pkgNormalize(workingDir, sourcePkg.key),
+          targets,
+          options,
+        );
+      }
     }
 
     if (options.dryRun) {
@@ -196,7 +205,6 @@ Commit: $commitInfo
 
 package:peanut $packageVersion''';
     }
-
     final commit = await gitDir.updateBranchWithDirectoryContents(
         options.branch, tempDir.path, message);
 

--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -122,7 +122,7 @@ Directories: ${sourcePkg.value.join(', ')}'''));
       if (isFlutterSdk()) {
         await runFlutterBuild(
           pkgNormalize(workingDir, sourcePkg.key),
-          tempDir.path,
+          targets,
           options,
         );
       } else {

--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -119,7 +119,7 @@ Future<void> run({Options options, String workingDir}) async {
 Package:     $pkgPath$countDetails
 Directories: ${sourcePkg.value.join(', ')}'''));
 
-      if (isFlutterSdk()) {
+      if (isFlutterSdk) {
         await runFlutterBuild(
           pkgNormalize(workingDir, sourcePkg.key),
           targets,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -36,21 +36,23 @@ final String _sdkDir = (() {
   return aboveExecutable;
 })();
 
-bool isFlutterSdk() {
+final bool isFlutterSdk = (() {
   final depth = 7;
   final components = p.split(Platform.resolvedExecutable);
   if (components.length < depth) {
     return false;
   }
+
+  // Assume that the Flutter SDK is installed in a directory named 'flutter'
   return components[components.length - depth] == 'flutter';
-}
+})();
 
 final String flutterPath = p.join(
     _flutterSdkDir, 'bin', Platform.isWindows ? 'flutter.bat' : 'flutter');
 
 /// The path to the root directory of the Flutter SDK.
 String _flutterSdkDir = (() {
-  assert(isFlutterSdk());
+  assert(isFlutterSdk);
   // The Flutter executable is in
   // "/path/to/flutter/sdk/bin/cache/dart-sdk/bin/dart", so 5 levels up is
   // "/path/to/flutter/sdk".

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -35,3 +35,28 @@ final String _sdkDir = (() {
   assert(FileSystemEntity.isFileSync(p.join(aboveExecutable, 'version')));
   return aboveExecutable;
 })();
+
+bool isFlutterSdk() {
+  final depth = 7;
+  final components = p.split(Platform.resolvedExecutable);
+  if (components.length < depth) {
+    return false;
+  }
+  return components[components.length - depth] == 'flutter';
+}
+
+final String flutterPath = p.join(
+    _flutterSdkDir, 'bin', Platform.isWindows ? 'flutter.bat' : 'flutter');
+
+/// The path to the root directory of the Flutter SDK.
+String _flutterSdkDir = (() {
+  assert(isFlutterSdk());
+  // The Flutter executable is in
+  // "/path/to/flutter/sdk/bin/cache/dart-sdk/bin/dart", so 5 levels up is
+  // "/path/to/flutter/sdk".
+  var dir = Platform.resolvedExecutable;
+  for (var i = 0; i < 5; i++) {
+    dir = p.dirname(dir);
+  }
+  return dir;
+})();

--- a/lib/src/webdev.dart
+++ b/lib/src/webdev.dart
@@ -18,7 +18,7 @@ import 'utils.dart';
 
 Future _runPubDeps(String workingDirectory) async {
   ProcessResult result;
-  if (isFlutterSdk()) {
+  if (isFlutterSdk) {
     result = Process.runSync(flutterPath, ['packages', 'deps'],
         workingDirectory: workingDirectory);
   } else {
@@ -32,7 +32,7 @@ Future _runPubDeps(String workingDirectory) async {
 
   if (result.exitCode != 0) {
     throw ProcessException(
-        isFlutterSdk() ? flutterPath : pubPath,
+        isFlutterSdk ? flutterPath : pubPath,
         ['deps'],
         '***OUT***\n${result.stdout}\n***ERR***\n${result.stderr}\n***',
         exitCode);
@@ -43,7 +43,7 @@ Future<void> checkPubspecLock(String pkgDir) async {
   final pubspecLock = await _PubspecLock.read(pkgDir);
 
   final issues = <PackageExceptionDetails>[];
-  if (!isFlutterSdk()) {
+  if (!isFlutterSdk) {
     issues
       ..addAll(pubspecLock.checkPackage(
           'build_runner', VersionConstraint.parse('>=1.3.0 <2.0.0')))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,32 +1,40 @@
 name: peanut
-author: Kevin Moore <github@j832.com>
 version: 3.4.0
+description: >-
+  Update your GitHub gh-pages branch with the compiled output of your Dart web
+  app. Supports 'pub build' and the new 'pub run build_runner'.
+author: Kevin Moore <github@j832.com>
 homepage: https://github.com/kevmoo/peanut.dart
-description: Update your GitHub gh-pages branch with the compiled output of your Dart web app. Supports 'pub build' and the new 'pub run build_runner'.
-environment: 
+environment:
   sdk: '>=2.3.0 <3.0.0'
-dependencies: 
-  pub_semver: ^1.4.0
+
+dependencies:
   args: ^1.5.1
-  checked_yaml: ^1.0.0
-  path: ^1.3.4
-  meta: ^1.0.0
-  git: ^1.0.0
-  yaml: ^2.1.0
-  json_annotation: ^3.0.0
-  glob: ^1.1.5
   build_cli_annotations: ^1.0.0
+  checked_yaml: ^1.0.0
+  git: ^1.0.0
+  glob: ^1.1.5
   io: ^0.3.2+1
-dev_dependencies: 
-  build_runner: ^1.0.0
-  test: ^1.6.0
-  build_web_compilers: '>=1.0.0 <=3.0.0'
-  pedantic: ^1.3.0
-  test_process: ^1.0.1
-  build_version: ^2.0.0
-  json_serializable: ^3.2.0
-  test_descriptor: ^1.1.1
+  json_annotation: ^3.0.0
+  meta: ^1.0.0
+  path: ^1.3.4
+  pub_semver: ^1.4.0
+  yaml: ^2.1.0
+
+dev_dependencies:
   build_cli: ^1.0.0
+  build_runner: ^1.0.0
   build_verify: ^1.1.1
-executables: 
+  build_version: ^2.0.0
+
+  # build_web_compilers is here to support the `example` dir
+  build_web_compilers: '>=1.0.0 <=3.0.0'
+
+  json_serializable: ^3.2.0
+  pedantic: ^1.3.0
+  test: ^1.6.0
+  test_descriptor: ^1.1.1
+  test_process: ^1.0.1
+
+executables:
   peanut: peanut

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,40 +1,32 @@
 name: peanut
-version: 3.3.0
-description: >-
-  Update your GitHub gh-pages branch with the compiled output of your Dart web
-  app. Supports 'pub build' and the new 'pub run build_runner'.
 author: Kevin Moore <github@j832.com>
+version: 3.4.0
 homepage: https://github.com/kevmoo/peanut.dart
-environment:
+description: Update your GitHub gh-pages branch with the compiled output of your Dart web app. Supports 'pub build' and the new 'pub run build_runner'.
+environment: 
   sdk: '>=2.3.0 <3.0.0'
-
-dependencies:
-  args: ^1.5.1
-  build_cli_annotations: ^1.0.0
-  checked_yaml: ^1.0.0
-  git: ^1.0.0
-  glob: ^1.1.5
-  io: ^0.3.2+1
-  json_annotation: ^3.0.0
-  meta: ^1.0.0
-  path: ^1.3.4
+dependencies: 
   pub_semver: ^1.4.0
+  args: ^1.5.1
+  checked_yaml: ^1.0.0
+  path: ^1.3.4
+  meta: ^1.0.0
+  git: ^1.0.0
   yaml: ^2.1.0
-
-dev_dependencies:
-  build_cli: ^1.0.0
+  json_annotation: ^3.0.0
+  glob: ^1.1.5
+  build_cli_annotations: ^1.0.0
+  io: ^0.3.2+1
+dev_dependencies: 
   build_runner: ^1.0.0
-  build_verify: ^1.1.1
-  build_version: ^2.0.0
-
-  # build_web_compilers is here to support the `example` dir
-  build_web_compilers: '>=1.0.0 <=3.0.0'
-
-  json_serializable: ^3.2.0
-  pedantic: ^1.3.0
   test: ^1.6.0
-  test_descriptor: ^1.1.1
+  build_web_compilers: '>=1.0.0 <=3.0.0'
+  pedantic: ^1.3.0
   test_process: ^1.0.1
-
-executables:
+  build_version: ^2.0.0
+  json_serializable: ^3.2.0
+  test_descriptor: ^1.1.1
+  build_cli: ^1.0.0
+  build_verify: ^1.1.1
+executables: 
   peanut: peanut


### PR DESCRIPTION
Detects if the current process uses the flutter sdk and uses `flutter build web` instead of `build_runner`.

For example, 

```
flutter pub global activate --source git git@github.com:johnpryan/peanut.dart.git
flutter pub global run peanut:peanut
```

A few things to call out:

1. This approach simply executes `flutter build web` and copies the files to the temp directory. I'm not sure if there's a way to use build_runner for flutter for web apps.
2. `flutter pub global activate` produces a bash file that runs `pub global run peanut:peanut "$@"` - but really this should be `flutter packages global run...` for Flutter users. (There is no `pub` when the Flutter SDK is installed) That's why `flutter pub global run peanut:peanut` is required here and not just `peanut`.
3. If the Dart SDK and  **and** Flutter SDK are both installed, users still need to activate and run peanut with the flutter command since the path is detected using `Platform.resolvedExecutable`

Once published, users should be able to run:

```
flutter pub global activate peanut
flutter pub global run peanut:peanut
```

closes #62 