### PR TITLE
Support FVM installations

### DIFF
--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -222,6 +222,11 @@ package:peanut $packageVersion''';
         'Branch "${options.branch}" was updated with commit $shortSha',
       ));
       print(indentedMessage);
+      if (options.branch == 'gh-pages') {
+        print('To push your gh-pages branch to github '
+            '(without switching from your working branch), run:\n'
+            '  git push origin --set-upstream gh-pages');
+      }
     }
   } finally {
     await tempDir.delete(recursive: true);

--- a/test/flutter_test.dart
+++ b/test/flutter_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+import 'package:peanut/src/utils.dart';
+
+void main() {
+  group('detecting Flutter SDK', () {
+    final dartSubPath = 'sdk/bin/cache/dart-sdk/bin'.split('/');
+
+    test('true negative', () {
+      final path = ['some', 'path', 'that', 'clearly', "isn't", 'that'];
+      expect(isFlutterSdkHeuristic(path), isFalse);
+    });
+
+    test('true positive (classic installation)', () {
+      final path = ['Users', 'johndoe', 'dev', 'flutter', ...dartSubPath];
+      expect(isFlutterSdkHeuristic(path), isTrue);
+    });
+
+    test('true positive (FVM installation)', () {
+      final path = ['Users', 'me', 'fvm', 'versions', 'beta', ...dartSubPath];
+      expect(isFlutterSdkHeuristic(path), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
FVM is a popular Flutter version management tool. It installs Flutter SDKs into directories that are _not_ named `flutter`, which breaks peanut’s heuristic.

Fixes #95.