### PR TITLE
Add helpful hint

### DIFF
--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -222,6 +222,11 @@ package:peanut $packageVersion''';
         'Branch "${options.branch}" was updated with commit $shortSha',
       ));
       print(indentedMessage);
+      if (options.branch == 'gh-pages') {
+        print('To push your gh-pages branch to github '
+            '(without switching from your working branch), run:\n'
+            '  git push origin --set-upstream gh-pages');
+      }
     }
   } finally {
     await tempDir.delete(recursive: true);


### PR DESCRIPTION
After running `peanut`, producing a `gh-pages` branch, the user might want to be reminded about the correct git command for pushing to GitHub.

This is something I wanted `peanut` to do for a long time. I always have to go online to get reminded about the correct git incantation. I believe other users will find this useful, too.