### PR TITLE
Add version-info cli option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.0-wip
+
+- Add `--version-info` option. This is off by default.
+
 ## 5.1.0
 
 - Support build wasm option for Flutter web.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Arguments:
     --[no-]source-branch-info    Includes the name of the source branch and SHA
                                  in the commit message
                                  (defaults to on)
+    --[no-]version-info          Includes the pubspec version of the package in
+                                 the commit message
     --post-build-dart-script     Optional Dart script to run after all builds
                                  have completed, but before files are committed
                                  to the repository.

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -100,6 +100,15 @@ Flutter: enabled passes `--release`, otherwise passes `--profile`.
   final bool sourceBranchInfoWasParsed;
 
   @CliOption(
+    defaultsTo: _defaultVersionInfo,
+    help: 'Includes the pubspec version of the package in the commit message',
+  )
+  final bool versionInfo;
+
+  @JsonKey(includeToJson: false, includeFromJson: false)
+  final bool versionInfoWasParsed;
+
+  @CliOption(
     help: 'Optional Dart script to run after all builds have completed, but '
         'before files are committed to the repository.',
   )
@@ -187,15 +196,6 @@ See the README for details.''',
     help: 'Print the current version.',
   )
   final bool version;
-
-  @CliOption(
-    defaultsTo: _defaultVersionInfo,
-    help: 'Includes the pubspec version of the package in the commit message',
-  )
-  final bool versionInfo;
-
-  @JsonKey(includeToJson: false, includeFromJson: false)
-  final bool versionInfoWasParsed;
 
   @JsonKey(includeToJson: false, includeFromJson: false)
   final bool extraArgsWasParsed;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -14,6 +14,7 @@ const _defaultRelease = true;
 const _defaultVerbose = false;
 const _defaultSourceBranchInfo = true;
 const _defaultDryRun = false;
+const _defaultVersionInfo = false;
 const _defaultWebRenderer = WebRenderer.auto;
 
 const defaultMessage = 'Built <$_directoryFlag>';
@@ -187,6 +188,15 @@ See the README for details.''',
   )
   final bool version;
 
+  @CliOption(
+    defaultsTo: _defaultVersionInfo,
+    help: 'Includes the pubspec version of the package in the commit message',
+  )
+  final bool versionInfo;
+
+  @JsonKey(includeToJson: false, includeFromJson: false)
+  final bool versionInfoWasParsed;
+
   @JsonKey(includeToJson: false, includeFromJson: false)
   final bool extraArgsWasParsed;
 
@@ -220,6 +230,8 @@ See the README for details.''',
     this.extraArgs,
     this.help = false,
     this.version = false,
+    this.versionInfo = _defaultVersionInfo,
+    this.versionInfoWasParsed = false,
     this.rest = const [],
   });
 
@@ -252,6 +264,7 @@ See the README for details.''',
       sourceBranchInfo:
           sourceBranchInfoWasParsed ? sourceBranchInfo : other.sourceBranchInfo,
       version: version,
+      versionInfo: versionInfoWasParsed ? versionInfo : other.versionInfo,
       verbose: verboseWasParsed ? verbose : other.verbose,
     );
   }

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -94,10 +94,6 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
         'Includes the name of the source branch and SHA in the commit message',
     defaultsTo: true,
   )
-  ..addFlag(
-    'version-info',
-    help: 'Includes the pubspec version of the package in the commit message',
-  )
   ..addOption(
     'post-build-dart-script',
     help:
@@ -152,6 +148,10 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     'version',
     help: 'Print the current version.',
     negatable: false,
+  )
+  ..addFlag(
+    'version-info',
+    help: 'Includes the pubspec version of the package in the commit message',
   );
 
 final _$parserForOptions = _$populateOptionsParser(ArgParser());
@@ -183,7 +183,8 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
             'verbose',
             'web-renderer',
             'wasm',
-            'extra-args'
+            'extra-args',
+            'version-info'
           ],
         );
         final val = Options(
@@ -207,8 +208,6 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
               'builder-options', (v) => _builderOptionsFromMap(v as Map?)),
           verbose:
               $checkedConvert('verbose', (v) => v as bool? ?? _defaultVerbose),
-          versionInfo: $checkedConvert(
-              'version-info', (v) => v as bool? ?? _defaultVersionInfo),
           webRenderer: $checkedConvert(
               'web-renderer',
               (v) =>
@@ -216,6 +215,8 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
                   _defaultWebRenderer),
           wasm: $checkedConvert('wasm', (v) => v as bool? ?? false),
           extraArgs: $checkedConvert('extra-args', (v) => v as String?),
+          versionInfo: $checkedConvert(
+              'version-info', (v) => v as bool? ?? _defaultVersionInfo),
         );
         return val;
       },
@@ -224,9 +225,9 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
         'sourceBranchInfo': 'source-branch-info',
         'postBuildDartScript': 'post-build-dart-script',
         'builderOptions': 'builder-options',
-        'versionInfo': 'version-info',
         'webRenderer': 'web-renderer',
-        'extraArgs': 'extra-args'
+        'extraArgs': 'extra-args',
+        'versionInfo': 'version-info'
       },
     );
 
@@ -249,10 +250,10 @@ Map<String, dynamic> _$OptionsToJson(Options instance) {
   writeNotNull('post-build-dart-script', instance.postBuildDartScript);
   writeNotNull('builder-options', instance.builderOptions);
   val['verbose'] = instance.verbose;
-  val['version-info'] = instance.versionInfo;
   val['web-renderer'] = _$WebRendererEnumMap[instance.webRenderer]!;
   val['wasm'] = instance.wasm;
   writeNotNull('extra-args', instance.extraArgs);
+  val['version-info'] = instance.versionInfo;
   return val;
 }
 

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -49,6 +49,8 @@ Options _$parseOptionsResult(ArgResults result) => Options(
       extraArgs: result['extra-args'] as String?,
       help: result['help'] as bool,
       version: result['version'] as bool,
+      versionInfo: result['version-info'] as bool,
+      versionInfoWasParsed: result.wasParsed('version-info'),
       rest: result.rest,
     );
 
@@ -91,6 +93,10 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     help:
         'Includes the name of the source branch and SHA in the commit message',
     defaultsTo: true,
+  )
+  ..addFlag(
+    'version-info',
+    help: 'Includes the pubspec version of the package in the commit message',
   )
   ..addOption(
     'post-build-dart-script',
@@ -201,6 +207,8 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
               'builder-options', (v) => _builderOptionsFromMap(v as Map?)),
           verbose:
               $checkedConvert('verbose', (v) => v as bool? ?? _defaultVerbose),
+          versionInfo: $checkedConvert(
+              'version-info', (v) => v as bool? ?? _defaultVersionInfo),
           webRenderer: $checkedConvert(
               'web-renderer',
               (v) =>
@@ -216,6 +224,7 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
         'sourceBranchInfo': 'source-branch-info',
         'postBuildDartScript': 'post-build-dart-script',
         'builderOptions': 'builder-options',
+        'versionInfo': 'version-info',
         'webRenderer': 'web-renderer',
         'extraArgs': 'extra-args'
       },
@@ -240,6 +249,7 @@ Map<String, dynamic> _$OptionsToJson(Options instance) {
   writeNotNull('post-build-dart-script', instance.postBuildDartScript);
   writeNotNull('builder-options', instance.builderOptions);
   val['verbose'] = instance.verbose;
+  val['version-info'] = instance.versionInfo;
   val['web-renderer'] = _$WebRendererEnumMap[instance.webRenderer]!;
   val['wasm'] = instance.wasm;
   writeNotNull('extra-args', instance.extraArgs);

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -94,6 +94,10 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
         'Includes the name of the source branch and SHA in the commit message',
     defaultsTo: true,
   )
+  ..addFlag(
+    'version-info',
+    help: 'Includes the pubspec version of the package in the commit message',
+  )
   ..addOption(
     'post-build-dart-script',
     help:
@@ -148,10 +152,6 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     'version',
     help: 'Print the current version.',
     negatable: false,
-  )
-  ..addFlag(
-    'version-info',
-    help: 'Includes the pubspec version of the package in the commit message',
   );
 
 final _$parserForOptions = _$populateOptionsParser(ArgParser());
@@ -178,13 +178,13 @@ Options _$OptionsFromJson(Map json) => $checkedCreate(
             'release',
             'message',
             'source-branch-info',
+            'version-info',
             'post-build-dart-script',
             'builder-options',
             'verbose',
             'web-renderer',
             'wasm',
-            'extra-args',
-            'version-info'
+            'extra-args'
           ],
         );
         final val = Options(
@@ -247,13 +247,13 @@ Map<String, dynamic> _$OptionsToJson(Options instance) {
   val['release'] = instance.release;
   val['message'] = instance.message;
   val['source-branch-info'] = instance.sourceBranchInfo;
+  val['version-info'] = instance.versionInfo;
   writeNotNull('post-build-dart-script', instance.postBuildDartScript);
   writeNotNull('builder-options', instance.builderOptions);
   val['verbose'] = instance.verbose;
   val['web-renderer'] = _$WebRendererEnumMap[instance.webRenderer]!;
   val['wasm'] = instance.wasm;
   writeNotNull('extra-args', instance.extraArgs);
-  val['version-info'] = instance.versionInfo;
   return val;
 }
 

--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -210,12 +210,11 @@ Directories:
     }
 
     if (options.versionInfo) {
-      final version = await getPackageVersion();
+      final version = await getPackageVersion(workingDir);
       message = '''
 $message
 
-Version: ${version ?? 'Unknown'}
-''';
+Version: ${version ?? 'Unknown'}''';
     }
 
     if (options.sourceBranchInfo) {

--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -209,6 +209,15 @@ Directories:
       }
     }
 
+    if (options.versionInfo) {
+      final version = await getPackageVersion();
+      message = '''
+$message
+
+Version: ${version ?? 'Unknown'}
+''';
+    }
+
     if (options.sourceBranchInfo) {
       final currentBranch = await gitDir.currentBranch();
       var commitInfo = currentBranch.sha;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0';
+const packageVersion = '5.2.0-wip';

--- a/lib/src/webdev.dart
+++ b/lib/src/webdev.dart
@@ -73,8 +73,8 @@ Future<void> checkPubspecLock(String pkgDir) async {
   }
 }
 
-Future<String?> getPackageVersion() async {
-  final pubSpec = await _Pubspec.read();
+Future<String?> getPackageVersion(String workingDir) async {
+  final pubSpec = await _Pubspec.read(workingDir);
   return pubSpec.version;
 }
 
@@ -85,8 +85,10 @@ class _Pubspec {
 
   _Pubspec(this._pubspec);
 
-  static Future<_Pubspec> read() async {
-    final pubSpec = loadYaml(await File(pubspecFile).readAsString()) as YamlMap;
+  static Future<_Pubspec> read(String workingDir) async {
+    final pubSpec =
+        loadYaml(await File(p.join(workingDir, pubspecFile)).readAsString())
+            as YamlMap;
 
     return _Pubspec(pubSpec);
   }

--- a/lib/src/webdev.dart
+++ b/lib/src/webdev.dart
@@ -73,6 +73,27 @@ Future<void> checkPubspecLock(String pkgDir) async {
   }
 }
 
+Future<String?> getPackageVersion() async {
+  final pubSpec = await _Pubspec.read();
+  return pubSpec.version;
+}
+
+const String pubspecFile = 'pubspec.yaml';
+
+class _Pubspec {
+  final YamlMap? _pubspec;
+
+  _Pubspec(this._pubspec);
+
+  static Future<_Pubspec> read() async {
+    final pubSpec = loadYaml(await File(pubspecFile).readAsString()) as YamlMap;
+
+    return _Pubspec(pubSpec);
+  }
+
+  String? get version => _pubspec?['version'] as String?;
+}
+
 class _PubspecLock {
   final YamlMap? _packages;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: peanut
-version: 5.1.0
+version: 5.2.0-wip
 description: >-
   Update your GitHub gh-pages branch with the compiled output of your Dart web
   app. Supports 'pub build' and the new 'pub run build_runner'.

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -28,6 +28,8 @@ Arguments:
     --[no-]source-branch-info    Includes the name of the source branch and SHA
                                  in the commit message
                                  (defaults to on)
+    --[no-]version-info          Includes the pubspec version of the package in
+                                 the commit message
     --post-build-dart-script     Optional Dart script to run after all builds
                                  have completed, but before files are committed
                                  to the repository.

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -133,6 +133,8 @@ void _checkDefault(
   expect(options.sourceBranchInfoWasParsed, wasParsed);
   expect(options.verbose, expected.verbose);
   expect(options.verboseWasParsed, wasParsed);
+  expect(options.versionInfo, expected.versionInfo);
+  expect(options.versionInfoWasParsed, expected.versionInfoWasParsed);
   expect(options.wasm, expected.wasm);
 
   expect(options.version, jsonSkippedDefault ?? expected.version);


### PR DESCRIPTION
My website is set up so that my PWA will pull updates if the version has been incremented. This means that my workflow usually involves incrementing the version before a big change and it'd be nice to keep track of which version is live. An option on the CLI to include this in the commit message would be nice to have.

I am not entirely sure how to test this myself, the logic seems pretty simple but I'm happy to test this with some guidance.