### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   # build_web_compilers is here to support the `example` dir
   build_web_compilers: ^4.2.3
 
+  checks: ^0.3.1
   dart_flutter_team_lints: ^3.0.0
   json_serializable: ^6.11.1
   # Needed because we are configuring `combining_builder`

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 
 import 'package:checked_yaml/checked_yaml.dart';
+import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:peanut/src/options.dart';
 import 'package:peanut/src/utils.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
@@ -55,7 +56,7 @@ void main() {
     final proc = await _runPeanut(['--help']);
 
     final output = await proc.stdoutStream().join('\n');
-    expect(output, _output);
+    check(output).equals(_output);
 
     await proc.shouldExit(0);
   });
@@ -63,14 +64,14 @@ void main() {
   test('readme', onPlatform: {'windows': const Skip()}, () {
     final content = File('README.md').readAsStringSync();
 
-    expect(content, contains(_output));
+    check(content).contains(_output);
   });
 
   test('bad flag', () async {
     final proc = await _runPeanut(['--bob']);
 
     final output = await proc.stdoutStream().join('\n');
-    expect(output, '''
+    check(output).equals('''
 Could not find an option named "--bob".
 
 $_output''');
@@ -82,7 +83,7 @@ $_output''');
     final proc = await _runPeanut(['foo', 'bar', 'baz']);
 
     final output = await proc.stdoutStream().join('\n');
-    expect(output, '''
+    check(output).equals('''
 I don't understand the extra arguments: foo, bar, baz
 
 $_output''');
@@ -92,16 +93,14 @@ $_output''');
 
   group('builder options', () {
     test('not provided', () async {
-      expect(parseOptions([]).builderOptions, isNull);
+      check(parseOptions([]).builderOptions).isNull();
     });
 
-    void expectParseOptionsThrows(List<String> args, Object matcher) {
-      expect(
-        () => parseOptions(args),
-        throwsA(
-          isFormatException.having((e) => e.toString(), 'toString()', matcher),
-        ),
-      );
+    void expectParseOptionsThrows(List<String> args, String expectedMessage) {
+      check(() => parseOptions(args))
+          .throws<FormatException>()
+          .has((e) => e.toString(), 'toString()')
+          .equals(expectedMessage);
     }
 
     group('config file', () {
@@ -118,8 +117,9 @@ FormatException: "$_someFilePath" is neither a path to a YAML file nor a YAML ma
 
         final options = parseOptions(['--builder-options', _someFilePath]);
 
-        expect(options.builderOptions, hasLength(1));
-        expect(options.builderOptions, containsPair('bob', {'jones': 42}));
+        final builderOptions = check(options.builderOptions).isNotNull();
+        builderOptions.length.equals(1);
+        builderOptions['bob'].deepEquals({'jones': 42});
       });
 
       test('invalid file', () async {
@@ -147,24 +147,18 @@ FormatException: "$_someFilePath" is neither a path to a YAML file nor a YAML ma
         () async {
           await d.file('some_file.yaml', '{').create();
 
-          expect(
-            () => parseOptions(['--builder-options', _someFilePath]),
-            throwsA(
-              isA<ParsedYamlException>().having(
-                (e) {
-                  printOnFailure(e.formattedMessage ?? '');
-                  return e.formattedMessage;
-                },
-                'formattedMessage',
-                '''
+          check(() => parseOptions(['--builder-options', _someFilePath]))
+              .throws<ParsedYamlException>()
+              .has((e) {
+                printOnFailure(e.formattedMessage ?? '');
+                return e.formattedMessage;
+              }, 'formattedMessage')
+              .equals('''
 line 1, column 2 of $_someFilePath: Expected node content.
   ╷
 1 │ {
   │  ^
-  ╵''',
-              ),
-            ),
-          );
+  ╵''');
         },
       );
     });

--- a/test/ensure_build_test.dart
+++ b/test/ensure_build_test.dart
@@ -4,7 +4,7 @@
 library;
 
 import 'package:build_verify/build_verify.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('ensure_build', expectBuildClean);

--- a/test/helper_test.dart
+++ b/test/helper_test.dart
@@ -1,8 +1,9 @@
 @TestOn('!windows')
 library;
 
+import 'package:checks/checks.dart';
 import 'package:peanut/src/helpers.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void _test(
   List<String> directories,
@@ -10,8 +11,11 @@ void _test(
   Map<String, String> outputMap,
 ) {
   final value = targetDirectories('root', directories);
-  expect(value, expectedTargetDirectories, reason: 'target directories');
-  expect(outputDirectoryMap(value), outputMap, reason: 'output map');
+  check(
+    because: 'target directories',
+    value,
+  ).deepEquals(expectedTargetDirectories);
+  check(because: 'output map', outputDirectoryMap(value)).deepEquals(outputMap);
 }
 
 void main() {

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:peanut/src/options.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
@@ -7,19 +8,15 @@ void main() {
   final emptyFileOptions = decodeYaml({});
 
   test('empty args', () {
-    _checkDefault(emptyArgsOptions, _defaultOptions, isFalse);
+    _checkDefault(emptyArgsOptions, _defaultOptions);
   });
 
   test('empty file', () {
-    _checkDefault(emptyFileOptions, _defaultOptions, isNull);
+    _checkDefault(emptyFileOptions, _defaultOptions);
   });
 
   test('merged', () {
-    _checkDefault(
-      emptyArgsOptions.merge(emptyFileOptions),
-      _defaultOptions,
-      isNull,
-    );
+    _checkDefault(emptyArgsOptions.merge(emptyFileOptions), _defaultOptions);
   });
 
   test('all options', () {
@@ -60,7 +57,7 @@ void main() {
       '--verbose',
       '--version',
     ]);
-    _checkDefault(allArgsOptions, allOptions, isTrue, wasParsed: true);
+    _checkDefault(allArgsOptions, allOptions, wasParsed: true);
 
     final allFileOptions = decodeYaml({
       'branch': 'other-branch',
@@ -76,26 +73,20 @@ void main() {
       'source-branch-info': false,
       'wasm': false,
     });
-    _checkDefault(
-      allFileOptions,
-      allOptions,
-      isNull,
-      jsonSkippedDefault: false,
-    );
+    _checkDefault(allFileOptions, allOptions, jsonSkippedDefault: false);
 
     // empty args, full file
     _checkDefault(
       emptyArgsOptions.merge(allFileOptions),
       allOptions,
-      isNull,
       jsonSkippedDefault: false,
     );
 
     // all args, empty file
-    _checkDefault(allArgsOptions.merge(emptyFileOptions), allOptions, isNull);
+    _checkDefault(allArgsOptions.merge(emptyFileOptions), allOptions);
 
     // all args, full file
-    _checkDefault(allArgsOptions.merge(allFileOptions), allOptions, isNull);
+    _checkDefault(allArgsOptions.merge(allFileOptions), allOptions);
   });
 }
 
@@ -103,36 +94,42 @@ const _defaultOptions = Options();
 
 void _checkDefault(
   Options options,
-  Options expected,
-  Matcher parsedValue, {
+  Options expected, {
   bool? jsonSkippedDefault,
   bool wasParsed = false,
 }) {
-  expect(options.branch, expected.branch);
-  expect(options.branchWasParsed, wasParsed);
-  expect(options.buildConfig, expected.buildConfig);
-  expect(options.buildConfigWasParsed, wasParsed);
-  expect(options.builderOptions, expected.builderOptions);
-  expect(options.builderOptionsWasParsed, wasParsed);
-  expect(options.directories, expected.directories);
-  expect(options.directoriesWasParsed, wasParsed);
+  check(options.branch).equals(expected.branch);
+  check(options.branchWasParsed).equals(wasParsed);
+  check(options.buildConfig).equals(expected.buildConfig);
+  check(options.buildConfigWasParsed).equals(wasParsed);
 
-  expect(options.dryRun, jsonSkippedDefault ?? expected.dryRun);
-  expect(options.help, jsonSkippedDefault ?? expected.help);
+  final builderOptions = expected.builderOptions;
+  if (builderOptions == null) {
+    check(options.builderOptions).isNull();
+  } else {
+    check(options.builderOptions).isNotNull().deepEquals(builderOptions);
+  }
+  check(options.builderOptionsWasParsed).equals(wasParsed);
 
-  expect(options.message, expected.message);
-  expect(options.messageWasParsed, wasParsed);
-  expect(options.postBuildDartScript, expected.postBuildDartScript);
-  expect(options.postBuildDartScriptWasParsed, wasParsed);
-  expect(options.release, expected.release);
-  expect(options.releaseWasParsed, wasParsed);
-  expect(options.sourceBranchInfo, expected.sourceBranchInfo);
-  expect(options.sourceBranchInfoWasParsed, wasParsed);
-  expect(options.verbose, expected.verbose);
-  expect(options.verboseWasParsed, wasParsed);
-  expect(options.versionInfo, expected.versionInfo);
-  expect(options.versionInfoWasParsed, expected.versionInfoWasParsed);
-  expect(options.wasm, expected.wasm);
+  check(options.directories).deepEquals(expected.directories);
+  check(options.directoriesWasParsed).equals(wasParsed);
 
-  expect(options.version, jsonSkippedDefault ?? expected.version);
+  check(options.dryRun).equals(jsonSkippedDefault ?? expected.dryRun);
+  check(options.help).equals(jsonSkippedDefault ?? expected.help);
+
+  check(options.message).equals(expected.message);
+  check(options.messageWasParsed).equals(wasParsed);
+  check(options.postBuildDartScript).equals(expected.postBuildDartScript);
+  check(options.postBuildDartScriptWasParsed).equals(wasParsed);
+  check(options.release).equals(expected.release);
+  check(options.releaseWasParsed).equals(wasParsed);
+  check(options.sourceBranchInfo).equals(expected.sourceBranchInfo);
+  check(options.sourceBranchInfoWasParsed).equals(wasParsed);
+  check(options.verbose).equals(expected.verbose);
+  check(options.verboseWasParsed).equals(wasParsed);
+  check(options.versionInfo).equals(expected.versionInfo);
+  check(options.versionInfoWasParsed).equals(expected.versionInfoWasParsed);
+  check(options.wasm).equals(expected.wasm);
+
+  check(options.version).equals(jsonSkippedDefault ?? expected.version);
 }

--- a/test/peanut_test.dart
+++ b/test/peanut_test.dart
@@ -4,22 +4,20 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:checks/checks.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
 import 'package:peanut/src/peanut.dart';
 import 'package:peanut/src/peanut_exception.dart';
 import 'package:peanut/src/utils.dart';
 import 'package:peanut/src/version.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
-TypeMatcher _treeEntry(String name, String type) => isA<TreeEntry>()
-    .having((te) => te.name, 'name', name)
-    .having((te) => te.type, 'type', type);
-
-Matcher _throwsPeanutException(Object message) => throwsA(
-  isA<PeanutException>().having((pe) => pe.message, 'message', message),
-);
+void Function(Subject<TreeEntry>) _treeEntry(String name, String type) =>
+    (it) => it
+      ..has((te) => te.name, 'name').equals(name)
+      ..has((te) => te.type, 'type').equals(type);
 
 Future<void> _run({Options? options}) =>
     run(workingDirectory: d.sandbox, options: options ?? const Options());
@@ -28,9 +26,10 @@ void main() {
   test('not a git dir', () async {
     await _simplePackage();
 
-    await expectLater(
-      _run(),
-      _throwsPeanutException('Not a git directory: ${d.sandbox}'),
+    await check(_run()).throws<PeanutException>(
+      (it) => it
+          .has((pe) => pe.message, 'message')
+          .equals('Not a git directory: ${d.sandbox}'),
     );
   });
 
@@ -38,9 +37,12 @@ void main() {
     await _simplePackage();
     await _initGitDir();
 
-    await expectLater(
+    await check(
       _run(options: const Options(directories: [])),
-      _throwsPeanutException('At least one directory must be provided.'),
+    ).throws<PeanutException>(
+      (it) => it
+          .has((pe) => pe.message, 'message')
+          .equals('At least one directory must be provided.'),
     );
   });
 
@@ -49,11 +51,14 @@ void main() {
     await _pubGet();
     await _initGitDir();
 
-    await expectLater(
+    await check(
       _run(options: const Options(directories: ['../temp/silly'])),
-      _throwsPeanutException(
-        '"../temp/silly" is not in the working directory "${d.sandbox}".',
-      ),
+    ).throws<PeanutException>(
+      (it) => it
+          .has((pe) => pe.message, 'message')
+          .equals(
+            '"../temp/silly" is not in the working directory "${d.sandbox}".',
+          ),
     );
   });
 
@@ -62,12 +67,15 @@ void main() {
     await _pubGet();
     await _initGitDir();
 
-    await expectLater(
+    await check(
       _run(options: Options(directories: [d.sandbox])),
-      _throwsPeanutException(
-        '"${d.sandbox}" is the same as the working directory, '
-        'which is not allowed.',
-      ),
+    ).throws<PeanutException>(
+      (it) => it
+          .has((pe) => pe.message, 'message')
+          .equals(
+            '"${d.sandbox}" is the same as the working directory, '
+            'which is not allowed.',
+          ),
     );
   });
 
@@ -76,9 +84,12 @@ void main() {
     await _pubGet();
     await _initGitDir();
 
-    await expectLater(
+    await check(
       _run(options: const Options(branch: 'main')),
-      _throwsPeanutException('Cannot update the current branch "main".'),
+    ).throws<PeanutException>(
+      (it) => it
+          .has((pe) => pe.message, 'message')
+          .equals('Cannot update the current branch "main".'),
     );
   });
 
@@ -90,15 +101,14 @@ void main() {
 
     await _run();
 
-    expect(
+    check(
       (await gitDir.branches()).map((br) => br.branchName),
-      unorderedEquals(['main', 'gh-pages']),
-    );
+    ).unorderedEquals(['main', 'gh-pages']);
 
     final ghBranchRef = await gitDir.branchReference('gh-pages');
 
     final ghCommit = await gitDir.commitFromRevision(ghBranchRef!.sha);
-    expect(ghCommit.message, '''
+    check(ghCommit.message).equals('''
 Built web
 
 Branch: main
@@ -117,15 +127,14 @@ package:peanut $packageVersion''');
 
     await _run(options: const Options(versionInfo: true));
 
-    expect(
+    check(
       (await gitDir.branches()).map((br) => br.branchName),
-      unorderedEquals(['main', 'gh-pages']),
-    );
+    ).unorderedEquals(['main', 'gh-pages']);
 
     final ghBranchRef = await gitDir.branchReference('gh-pages');
 
     final ghCommit = await gitDir.commitFromRevision(ghBranchRef!.sha);
-    expect(ghCommit.message, '''
+    check(ghCommit.message).equals('''
 Built web
 
 Version: 1.0.0
@@ -146,15 +155,14 @@ package:peanut $packageVersion''');
 
     await _run(options: const Options(directories: ['example', 'web']));
 
-    expect(
+    check(
       (await gitDir.branches()).map((br) => br.branchName),
-      unorderedEquals(['main', 'gh-pages']),
-    );
+    ).unorderedEquals(['main', 'gh-pages']);
 
     final ghBranchRef = await gitDir.branchReference('gh-pages');
 
     final ghCommit = await gitDir.commitFromRevision(ghBranchRef!.sha);
-    expect(ghCommit.message, '''
+    check(ghCommit.message).equals('''
 Built example, web
 
 Branch: main
@@ -164,12 +172,11 @@ package:peanut $packageVersion''');
 
     final treeContents = await gitDir.lsTree(ghCommit.treeSha);
 
-    expect(
+    check(
       treeContents.map((te) => te.name),
-      unorderedEquals(['example', 'web', 'index.html']),
-    );
+    ).unorderedEquals(['example', 'web', 'index.html']);
 
-    expect(treeContents, contains(_treeEntry('index.html', 'blob')));
+    check(treeContents).any(_treeEntry('index.html', 'blob'));
 
     for (var te in treeContents.where((te) => te.type == 'tree')) {
       await _expectStandardTreeContents(gitDir, te.sha);
@@ -192,15 +199,14 @@ package:peanut $packageVersion''');
       ),
     );
 
-    expect(
+    check(
       (await gitDir.branches()).map((br) => br.branchName),
-      unorderedEquals(['main', 'gh-pages']),
-    );
+    ).unorderedEquals(['main', 'gh-pages']);
 
     final ghBranchRef = await gitDir.branchReference('gh-pages');
 
     final ghCommit = await gitDir.commitFromRevision(ghBranchRef!.sha);
-    expect(ghCommit.message, '''
+    check(ghCommit.message).equals('''
 Built pkg1/example, pkg1/web, pkg2/example, pkg2/web
 
 Branch: main
@@ -210,24 +216,20 @@ package:peanut $packageVersion''');
 
     final treeContents = await gitDir.lsTree(ghCommit.treeSha);
 
-    expect(
+    check(
       treeContents.map((te) => te.name),
-      unorderedEquals(packages.followedBy(['index.html'])),
-    );
+    ).unorderedEquals(packages.followedBy(['index.html']));
 
-    expect(treeContents, contains(_treeEntry('index.html', 'blob')));
+    check(treeContents).any(_treeEntry('index.html', 'blob'));
 
     final pkgTreeHashes = treeContents
         .where((te) => te.type == 'tree')
         .map((te) => te.sha)
         .toSet();
-    expect(pkgTreeHashes, hasLength(1), reason: 'should be identical');
+    check(because: 'should be identical', pkgTreeHashes).length.equals(1);
 
     final pkgContent = await gitDir.lsTree(pkgTreeHashes.single);
-    expect(
-      pkgContent.map((te) => te.name),
-      unorderedEquals(['example', 'web']),
-    );
+    check(pkgContent.map((te) => te.name)).unorderedEquals(['example', 'web']);
 
     for (var te in pkgContent) {
       await _expectStandardTreeContents(gitDir, te.sha);
@@ -257,15 +259,14 @@ void main(List<String> args) {
         ),
       );
 
-      expect(
+      check(
         (await gitDir.branches()).map((br) => br.branchName),
-        unorderedEquals(['main', 'gh-pages']),
-      );
+      ).unorderedEquals(['main', 'gh-pages']);
 
       final ghBranchRef = await gitDir.branchReference('gh-pages');
 
       final ghCommit = await gitDir.commitFromRevision(ghBranchRef!.sha);
-      expect(ghCommit.message, '''
+      check(ghCommit.message).equals('''
 Built example, web
 
 Branch: main
@@ -274,16 +275,13 @@ Commit: ${primaryCommit.single.sha}
 package:peanut $packageVersion''');
 
       final treeContents = await gitDir.lsTree(ghCommit.treeSha);
-      expect(
-        treeContents,
-        unorderedEquals([
-          _treeEntry('example', 'tree'),
-          _treeEntry('index.html', 'blob'),
-          _treeEntry('map.json', 'blob'),
-          _treeEntry('some_file.txt', 'blob'),
-          _treeEntry('web', 'tree'),
-        ]),
-      );
+      check(treeContents).unorderedMatches([
+        _treeEntry('example', 'tree'),
+        _treeEntry('index.html', 'blob'),
+        _treeEntry('map.json', 'blob'),
+        _treeEntry('some_file.txt', 'blob'),
+        _treeEntry('web', 'tree'),
+      ]);
 
       final mapJsonSha = treeContents
           .singleWhere((te) => te.name == 'map.json')
@@ -292,7 +290,7 @@ package:peanut $packageVersion''');
       final result = await gitDir.runCommand(['cat-file', '-p', mapJsonSha]);
       final mapOutput =
           jsonDecode(result.stdout as String) as Map<String, dynamic>;
-      expect(mapOutput, Map<String, dynamic>.fromIterable(buildDirs));
+      check(mapOutput).deepEquals(Map<String, dynamic>.fromIterable(buildDirs));
     });
 
     test('missing', () async {
@@ -300,14 +298,15 @@ package:peanut $packageVersion''');
       await _pubGet();
       await _initGitDir();
 
-      await expectLater(
+      await check(
         _run(options: const Options(postBuildDartScript: 'post_build.dart')),
-        _throwsPeanutException(
-          startsWith(
-            'The provided post-build Dart script does not exist '
-            'or is not a file.',
-          ),
-        ),
+      ).throws<PeanutException>(
+        (it) => it
+            .has((pe) => pe.message, 'message')
+            .startsWith(
+              'The provided post-build Dart script does not exist or '
+              'is not a file.',
+            ),
       );
     });
 
@@ -323,11 +322,12 @@ void main() {
       await _pubGet();
       await _initGitDir();
 
-      await expectLater(
+      await check(
         _run(options: const Options(postBuildDartScript: 'post_build.dart')),
-        _throwsPeanutException(
-          allOf(startsWith('Error running "'), endsWith('\nExit code 123')),
-        ),
+      ).throws<PeanutException>(
+        (it) => it.has((pe) => pe.message, 'message')
+          ..startsWith('Error running "')
+          ..endsWith('\nExit code 123'),
       );
     });
   });
@@ -340,12 +340,9 @@ Future<void> _expectStandardTreeContents(GitDir gitDir, String treeSha) async {
     final treeContents = await gitDir.lsTree(treeSha);
 
     try {
-      expect(treeContents, hasLength(2));
-      expect(
-        treeContents,
-        contains(_treeEntry('example_script.dart.js', 'blob')),
-      );
-      expect(treeContents, contains(_treeEntry('index.html', 'blob')));
+      check(treeContents).length.equals(2);
+      check(treeContents).any(_treeEntry('example_script.dart.js', 'blob'));
+      check(treeContents).any(_treeEntry('index.html', 'blob'));
 
       _standardTreeContentSha = treeSha;
     } catch (e) {
@@ -353,11 +350,10 @@ Future<void> _expectStandardTreeContents(GitDir gitDir, String treeSha) async {
       rethrow;
     }
   } else {
-    expect(
+    check(
+      because: 'Standard directory content should be identical across tests.',
       treeSha,
-      _standardTreeContentSha,
-      reason: 'Standard directory content should be identical across tests.',
-    );
+    ).equals(_standardTreeContentSha!);
   }
 }
 
@@ -368,16 +364,15 @@ Future<void> _pubGet({String? parent}) async {
     '--offline',
     '--no-precompile',
   ], workingDirectory: p.join(d.sandbox, parent));
-  expect(
-    proc.exitCode,
-    0,
-    reason: [
+  check(
+    because: [
       'STDOUT:',
       proc.stdout as String,
       'STDERR:',
       proc.stderr as String,
     ].map((str) => str.trim()).join('\n'),
-  );
+    proc.exitCode,
+  ).equals(0);
 }
 
 Future<GitDir> _initGitDir() async {
@@ -390,7 +385,9 @@ Future<GitDir> _initGitDir() async {
   await gitDir.runCommand(['add', '.']);
   await gitDir.runCommand(['commit', '-m', 'dummy commit']);
 
-  expect((await gitDir.branches()).map((br) => br.branchName), ['main']);
+  check(
+    (await gitDir.branches()).map((br) => br.branchName),
+  ).deepEquals(['main']);
   return gitDir;
 }
 


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).