### PR TITLE
refactor(validation): remove redundant directory boundary verification

### DIFF
--- a/lib/src/peanut.dart
+++ b/lib/src/peanut.dart
@@ -49,22 +49,6 @@ Future<void> run({
   // key: package dir; value: all dirs to build within that package
   final targetDirs = targetDirectories(workingDir, options.directories);
 
-  for (var dir in options.directories) {
-    final fullPath = pkgNormalize(workingDir, dir);
-
-    if (p.equals(workingDir, dir)) {
-      throw PeanutException(
-        '"$dir" is the same as the working directory, which is not allowed.',
-      );
-    }
-
-    if (!p.isWithin(workingDir, fullPath)) {
-      throw PeanutException(
-        '"$dir" is not in the working directory "$workingDir".',
-      );
-    }
-  }
-
   String prettyPkgPath(String pkgPath) => pkgPath == '.' ? workingDir : pkgPath;
 
   print(ansi.styleBold.wrap('Validating packages:'));


### PR DESCRIPTION
- Remove duplicate directory validation loop inside the run function.
- Rely on targetDirectories, which already asserts identical working directory boundaries and throws PeanutException.
- Eliminates repeated runtime iteration over input directories.
