### PR TITLE
style: format markdown files with 80-column line wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 
 ## 5.0.0
 
-- Now chooses the "mode" (`build_runner` or Flutter) based on if the detected package is a Flutter package.
+- Now chooses the "mode" (`build_runner` or Flutter) based on if the detected
+  package is a Flutter package.
 
 ## 4.3.1
 
@@ -93,9 +94,9 @@
 
 ## 3.4.0
 
-- Flutter apps are now built if peanut is enabled using `flutter pub global
-  activate`. Running `flutter pub global run peanut:peanut` will use the flutter
-  CLI instead of `build_runner`
+- Flutter apps are now built if peanut is enabled using
+  `flutter pub global activate`. Running `flutter pub global run peanut:peanut`
+  will use the flutter CLI instead of `build_runner`
 
 ## 3.3.0
 
@@ -114,8 +115,8 @@
 ## 3.2.0
 
 - If `post-build-dart-script` is provided, pass a second command line argument
-  after the build directory. A JSON map between the source directory relative
-  to the working directory and the corresponding build directory.
+  after the build directory. A JSON map between the source directory relative to
+  the working directory and the corresponding build directory.
 
 ## 3.1.1
 
@@ -160,104 +161,104 @@
 
 ## 2.0.6
 
-* Improve `--help` output.
+- Improve `--help` output.
 
 ## 2.0.5
 
-* Support the latest `package:build_runner`.
+- Support the latest `package:build_runner`.
 
 ## 2.0.4
 
-* Support Dart 2 stable. 
+- Support Dart 2 stable.
 
 ## 2.0.3
 
-* Updates to support latest `package:build_runner`.
+- Updates to support latest `package:build_runner`.
 
 ## 2.0.2
 
-* Require Dart `>=2.0.0-dev.56`.
+- Require Dart `>=2.0.0-dev.56`.
 
-* Other updates to support running on Dart 2.
+- Other updates to support running on Dart 2.
 
 ## 2.0.1
 
-* Support the latest version of `package:build_web_compilers`.
+- Support the latest version of `package:build_web_compilers`.
 
 ## 2.0.0
 
-* **BREAKING** Now *only* works with the latest `package:build_runner` and
-  friends. 
+- **BREAKING** Now _only_ works with the latest `package:build_runner` and
+  friends.
 
-* Removed manual file management that likely caused problems on Windows.
+- Removed manual file management that likely caused problems on Windows.
 
-* The public library has been removed. This package is meant to be an executable
+- The public library has been removed. This package is meant to be an executable
   only.
 
 ## 1.1.6
 
-* Moved non-executable file out of `/bin` so it's not activated during
+- Moved non-executable file out of `/bin` so it's not activated during
   `pub global activate`.
 
 ## 1.1.5
 
-* Run `pub` from the SDK invoking `peanut`. Also fixes the case where `pub` is
+- Run `pub` from the SDK invoking `peanut`. Also fixes the case where `pub` is
   not in the user's PATH.
 
-* Send all output to `stdout`.
+- Send all output to `stdout`.
 
-* Improve exit codes and error messages on failure.
+- Improve exit codes and error messages on failure.
 
 ## 1.1.4
 
-* Added `**.dart.js.deps`, `**.dart.js.tar.gz`, `**.ng_placeholder` to the set 
+- Added `**.dart.js.deps`, `**.dart.js.tar.gz`, `**.ng_placeholder` to the set
   of files to exclude.
 
 ## 1.1.3
 
-* Only warn if the `directory` does not exist. Build could still work.
+- Only warn if the `directory` does not exist. Build could still work.
 
-* Update dependency on `pkg:git`. Allows running `peanut` in a subdirectory of
-  a Git repository.
+- Update dependency on `pkg:git`. Allows running `peanut` in a subdirectory of a
+  Git repository.
 
 ## 1.1.2
 
-* Support the latest `pkg:git`.
+- Support the latest `pkg:git`.
 
 ## 1.1.1
 
-* Improve sub-process management.
+- Improve sub-process management.
 
-* Print error/warnings in red – where supported.
+- Print error/warnings in red – where supported.
 
 ## 1.1.0
 
-* Initial support for `build_runner` via `--build_tool` option.
+- Initial support for `build_runner` via `--build_tool` option.
 
-* Updated Dart SDK lower-bound to `2.0.0-dev.22`.
-  Using `Iterable.whereType<T>` – introduced in this release. 
+- Updated Dart SDK lower-bound to `2.0.0-dev.22`. Using `Iterable.whereType<T>`
+  – introduced in this release.
 
 ## 1.0.0
 
-* Set exit code correctly on errors.
+- Set exit code correctly on errors.
 
 ## 0.1.0
 
-* Tweak some things.
-* Update readme.
+- Tweak some things.
+- Update readme.
 
 ## 0.0.2
 
-* Add mode options, to allow `pub build` to run in debug mode.
+- Add mode options, to allow `pub build` to run in debug mode.
 
 ## 0.0.1+2
 
-* Run `pub` with `runInShell` to make things work on Windows.
+- Run `pub` with `runInShell` to make things work on Windows.
 
 ## 0.0.1+1
 
-* Added instructions to `README.md`.
+- Added instructions to `README.md`.
 
 ## 0.0.1
 
-* Initial version, created by [Stagehand](https://pub.dev/packages/stagehand)
+- Initial version, created by [Stagehand](https://pub.dev/packages/stagehand)

--- a/README.md
+++ b/README.md
@@ -136,11 +136,10 @@ It receives two arguments:
 
 For example, if you run `peanut -d web`, the script will be called with:
 
-*   `args[0]`: `/tmp/peanut.xyz` (a temporary path)
-*   `args[1]`: `{"web":"."}`
+- `args[0]`: `/tmp/peanut.xyz` (a temporary path)
+- `args[1]`: `{"web":"."}`
 
-The `index.html` for the `web` build would be at
-`/tmp/peanut.xyz/index.html`.
+The `index.html` for the `web` build would be at `/tmp/peanut.xyz/index.html`.
 
 ## Examples
 


### PR DESCRIPTION
- Wrap markdown prose within 80 columns using Prettier/mdf.
- Normalize bullet markers and standardize block whitespace.
