### PR TITLE
refactor: privatize pubspecFile constant in webdev.dart

### DIFF
--- a/lib/src/webdev.dart
+++ b/lib/src/webdev.dart
@@ -82,7 +82,7 @@ Future<String?> getPackageVersion(String workingDir) async {
   return pubSpec.version;
 }
 
-const String pubspecFile = 'pubspec.yaml';
+const String _pubspecFile = 'pubspec.yaml';
 
 class _Pubspec {
   final YamlMap? _pubspec;
@@ -91,7 +91,7 @@ class _Pubspec {
 
   static Future<_Pubspec> read(String workingDir) async {
     final pubSpec =
-        loadYaml(await File(p.join(workingDir, pubspecFile)).readAsString())
+        loadYaml(await File(p.join(workingDir, _pubspecFile)).readAsString())
             as YamlMap;
 
     return _Pubspec(pubSpec);


### PR DESCRIPTION
Make the top-level pubspecFile constant library-private (_pubspecFile),
as it is only referenced internally within webdev.dart.
