### PR TITLE
fix: use cli_util for dart discovery and handle unset FLUTTER_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.2
+
+- Fix AOT self-invocation loop when running `build_runner` by using `package:cli_util` for Dart SDK discovery.
+- Fix crash when `FLUTTER_ROOT` environment variable is unset.
+
 ## 6.0.1
 
 - Support Dart workspaces by resolving pubspec.lock up the directory tree

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:io/ansi.dart' as ansi;
 import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
@@ -38,16 +39,16 @@ Future<void> runProcess(
   }
 }
 
-String get dartPath => Platform.resolvedExecutable;
+String get dartPath => cli_util.dartExecutable ?? 'dart';
 
-final String flutterPath = p.join(
-  _flutterSdkDir,
-  'bin',
-  Platform.isWindows ? 'flutter.bat' : 'flutter',
-);
-
-/// The path to the root directory of the Flutter SDK.
-final String _flutterSdkDir = Platform.environment['FLUTTER_ROOT']!;
+String get flutterPath {
+  final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+  final flutterBin = Platform.isWindows ? 'flutter.bat' : 'flutter';
+  if (flutterRoot != null && flutterRoot.isNotEmpty) {
+    return p.join(flutterRoot, 'bin', flutterBin);
+  }
+  return flutterBin;
+}
 
 void checkValidOptions(String name, Set<String> config) {
   if (config.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: peanut
-version: 6.0.1
+version: 6.0.2
 description: >-
   Update your GitHub gh-pages branch with the compiled output of your Dart web
   app. Supports 'pub build' and the new 'pub run build_runner'.
@@ -11,6 +11,7 @@ dependencies:
   args: ^2.6.0
   build_cli_annotations: ^2.1.1
   checked_yaml: ^2.0.1
+  cli_util: ^0.6.0
   git: ^2.2.1
   glob: ^2.0.0
   io: ^1.0.0

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:path/path.dart' as p;
+import 'package:peanut/src/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('dartPath returns non-empty executable path', () {
+    check(dartPath).isNotEmpty();
+  });
+
+  test('flutterPath handles unset or set FLUTTER_ROOT without throwing', () {
+    final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+    final expectedBin = Platform.isWindows ? 'flutter.bat' : 'flutter';
+    if (flutterRoot != null && flutterRoot.isNotEmpty) {
+      check(flutterPath).equals(p.join(flutterRoot, 'bin', expectedBin));
+    } else {
+      check(flutterPath).equals(expectedBin);
+    }
+  });
+}


### PR DESCRIPTION
When compiled to native AOT or installed via `dart install`,
`Platform.resolvedExecutable` points to the `peanut` binary rather
than the Dart SDK `dart` binary, causing an infinite recursive loop
when spawning `build_runner`. Additionally, `FLUTTER_ROOT` was accessed
with an unsafe non-null assertion.

- Migrate `dartPath` to `cli_util.dartExecutable` for 4-tier SDK discovery.
- Handle nullable `FLUTTER_ROOT` in `flutterPath`.
- Add unit tests for `dartPath` and `flutterPath`.

Fixes #223
